### PR TITLE
feat(notion-vue): implement Collection List View

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,8 +35,8 @@ Quick reference for features not yet implemented in nuxt-notion-starter-kit.
   - Implemented: `packages/notion-vue/src/components/collection/CollectionViewGallery.vue`
 - [x] **Board View** - Kanban-style view
   - Implemented: `packages/notion-vue/src/components/collection/CollectionViewBoard.vue`
-- [ ] **List View** - Simplified list layout
-  - Ref: `ref/react-notion-x/packages/react-notion-x/src/third-party/collection-view-list.tsx`
+- [x] **List View** - Simplified list layout
+  - Implemented: `packages/notion-vue/src/components/collection/CollectionViewList.vue`
 
 ### Components
 - [x] **Page Aside (TOC)** - Table of contents sidebar
@@ -108,9 +108,11 @@ Quick reference for features not yet implemented in nuxt-notion-starter-kit.
 - [x] NotionBlock - All basic block types
 - [x] NotionText - All text decorations
 - [x] NotionAsset - Image, Video, Embed, Bookmark
-- [x] NotionCollection - Table view (MVP) + Gallery view + Board view
+- [x] NotionCollection - Table view (MVP) + Gallery view + Board view + List view
 - [x] NotionCode - Syntax highlighting with Shiki
 - [x] CollectionViewGallery - Gallery view with cover images and grouping
+- [x] CollectionViewBoard - Board (Kanban) view with columns
+- [x] CollectionViewList - List view with title and properties
 
 ### Layout Components
 - [x] NotionHeader - Site navigation header

--- a/packages/notion-vue/src/components/NotionCollection.vue
+++ b/packages/notion-vue/src/components/NotionCollection.vue
@@ -6,6 +6,7 @@ import { useCollectionData } from '../composables/useCollectionData'
 import { useNotionContext } from '../composables/useNotionContext'
 import CollectionViewBoard from './collection/CollectionViewBoard.vue'
 import CollectionViewGallery from './collection/CollectionViewGallery.vue'
+import CollectionViewList from './collection/CollectionViewList.vue'
 
 const props = defineProps<{
   block: Block
@@ -131,6 +132,14 @@ function isTitle(columnId: string): boolean {
     <!-- Board View -->
     <CollectionViewBoard
       v-else-if="viewType === 'board' && collectionView && collectionData"
+      :collection="collection"
+      :collection-view="collectionView"
+      :collection-data="collectionData"
+    />
+
+    <!-- List View -->
+    <CollectionViewList
+      v-else-if="viewType === 'list' && collectionView && collectionData"
       :collection="collection"
       :collection-view="collectionView"
       :collection-data="collectionData"

--- a/packages/notion-vue/src/components/collection/CollectionViewList.vue
+++ b/packages/notion-vue/src/components/collection/CollectionViewList.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import type { Collection, CollectionQueryResult, CollectionView, PageBlock } from 'notion-types'
+import type {
+  CollectionPropertyConfig,
+  ListCollectionViewFormat,
+} from '../../types/collection'
+import { computed } from 'vue'
+import { useCollectionGroups } from '../../composables/useCollectionGroups'
+import { useNotionContext } from '../../composables/useNotionContext'
+import CollectionGroup from './CollectionGroup.vue'
+import CollectionProperty from './CollectionProperty.vue'
+
+const props = defineProps<{
+  collection: Collection
+  collectionView: CollectionView
+  collectionData: CollectionQueryResult
+}>()
+
+const { recordMap, mapPageUrl } = useNotionContext()
+
+// Extract list format options
+const format = computed<ListCollectionViewFormat>(() => {
+  return (props.collectionView.format as ListCollectionViewFormat) || {}
+})
+
+const listProperties = computed<CollectionPropertyConfig[]>(() => {
+  return format.value.list_properties?.filter(p => p.visible) || []
+})
+
+// Use the groups composable
+const { isGrouped, groups, ungroupedBlockIds } = useCollectionGroups({
+  collection: () => props.collection,
+  collectionView: () => props.collectionView,
+  collectionData: () => props.collectionData,
+})
+
+// Get block from recordMap
+function getBlock(blockId: string): PageBlock | undefined {
+  return recordMap.block[blockId]?.value as PageBlock | undefined
+}
+
+// Get page icon from block format
+function getPageIcon(block: PageBlock): string | undefined {
+  return (block as unknown as { format?: { page_icon?: string } }).format?.page_icon
+}
+
+// Get title schema and data from block
+function getTitleData(block: PageBlock) {
+  const titleSchema = props.collection.schema.title
+  const titleData = block?.properties?.title
+  return { schema: titleSchema, data: titleData }
+}
+
+// Get property data for a block
+function getPropertyData(block: PageBlock, propertyId: string) {
+  const schema = props.collection.schema[propertyId]
+  const data = block?.properties?.[propertyId as keyof typeof block.properties]
+  return { schema, data }
+}
+</script>
+
+<template>
+  <div class="notion-list-collection">
+    <div class="notion-list-view">
+      <!-- Grouped List -->
+      <template v-if="isGrouped">
+        <CollectionGroup
+          v-for="group in groups"
+          :key="group.value"
+          :collection="collection"
+          :schema="group.schema"
+          :value="group.value"
+          :total="group.total"
+          :hidden="group.hidden"
+        >
+          <div class="notion-list-body">
+            <template v-for="blockId in group.blockIds" :key="blockId">
+              <a
+                v-if="getBlock(blockId)"
+                :href="mapPageUrl(blockId)"
+                class="notion-list-item notion-page-link"
+              >
+                <div class="notion-list-item-title">
+                  <span
+                    v-if="getPageIcon(getBlock(blockId)!)"
+                    class="notion-page-icon"
+                  >
+                    {{ getPageIcon(getBlock(blockId)!) }}
+                  </span>
+                  <CollectionProperty
+                    v-if="getTitleData(getBlock(blockId)!).schema"
+                    :schema="getTitleData(getBlock(blockId)!).schema!"
+                    :data="getTitleData(getBlock(blockId)!).data"
+                    :block="getBlock(blockId)"
+                    :collection="collection"
+                  />
+                </div>
+
+                <div v-if="listProperties.length > 0" class="notion-list-item-body">
+                  <template v-for="prop in listProperties" :key="prop.property">
+                    <div
+                      v-if="getPropertyData(getBlock(blockId)!, prop.property).schema"
+                      class="notion-list-item-property"
+                    >
+                      <CollectionProperty
+                        :schema="getPropertyData(getBlock(blockId)!, prop.property).schema!"
+                        :data="getPropertyData(getBlock(blockId)!, prop.property).data"
+                        :block="getBlock(blockId)"
+                        :collection="collection"
+                      />
+                    </div>
+                  </template>
+                </div>
+              </a>
+            </template>
+          </div>
+        </CollectionGroup>
+      </template>
+
+      <!-- Ungrouped List -->
+      <div v-else class="notion-list-body">
+        <template v-for="blockId in ungroupedBlockIds" :key="blockId">
+          <a
+            v-if="getBlock(blockId)"
+            :href="mapPageUrl(blockId)"
+            class="notion-list-item notion-page-link"
+          >
+            <div class="notion-list-item-title">
+              <span
+                v-if="getPageIcon(getBlock(blockId)!)"
+                class="notion-page-icon"
+              >
+                {{ getPageIcon(getBlock(blockId)!) }}
+              </span>
+              <CollectionProperty
+                v-if="getTitleData(getBlock(blockId)!).schema"
+                :schema="getTitleData(getBlock(blockId)!).schema!"
+                :data="getTitleData(getBlock(blockId)!).data"
+                :block="getBlock(blockId)"
+                :collection="collection"
+              />
+            </div>
+
+            <div v-if="listProperties.length > 0" class="notion-list-item-body">
+              <template v-for="prop in listProperties" :key="prop.property">
+                <div
+                  v-if="getPropertyData(getBlock(blockId)!, prop.property).schema"
+                  class="notion-list-item-property"
+                >
+                  <CollectionProperty
+                    :schema="getPropertyData(getBlock(blockId)!, prop.property).schema!"
+                    :data="getPropertyData(getBlock(blockId)!, prop.property).data"
+                    :block="getBlock(blockId)"
+                    :collection="collection"
+                  />
+                </div>
+              </template>
+            </div>
+          </a>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/notion-vue/src/index.ts
+++ b/packages/notion-vue/src/index.ts
@@ -5,6 +5,7 @@ export { default as CollectionGroup } from './components/collection/CollectionGr
 export { default as CollectionProperty } from './components/collection/CollectionProperty.vue'
 export { default as CollectionViewBoard } from './components/collection/CollectionViewBoard.vue'
 export { default as CollectionViewGallery } from './components/collection/CollectionViewGallery.vue'
+export { default as CollectionViewList } from './components/collection/CollectionViewList.vue'
 export { default as NestedFormLink } from './components/collection/NestedFormLink.vue'
 // Icons
 export { default as EmptyIcon } from './components/icons/EmptyIcon.vue'
@@ -56,6 +57,7 @@ export type {
   CollectionPropertyConfig,
   CollectionViewProps,
   GalleryCollectionViewFormat,
+  ListCollectionViewFormat,
 } from './types/collection'
 
 // Utils

--- a/packages/notion-vue/src/styles.css
+++ b/packages/notion-vue/src/styles.css
@@ -1258,6 +1258,80 @@
   height: 180px;
 }
 
+/* List View */
+.notion-list-collection {
+  width: 100%;
+  max-width: 100%;
+  align-self: center;
+}
+
+.notion-list-view {
+  position: relative;
+  padding-left: 0;
+  transition: padding 200ms ease-out;
+  max-width: 100%;
+}
+
+.notion-list-body {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--fg-color-1);
+  padding-top: 8px;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.notion-list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px;
+  margin: 1px 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 4px;
+  transition: background-color 100ms ease-in;
+}
+
+.notion-list-item:hover {
+  background-color: var(--bg-color-1);
+}
+
+.notion-list-item-title {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  line-height: 1.3;
+  gap: 6px;
+}
+
+.notion-list-item-title .notion-page-icon {
+  flex-shrink: 0;
+}
+
+.notion-list-item-body {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  gap: 8px;
+}
+
+.notion-list-item-property {
+  margin-left: 14px;
+  font-size: 14px;
+  color: var(--fg-color-3);
+}
+
+.notion-list-item-property .notion-property-select-item {
+  font-size: 12px;
+}
+
 /* Mobile responsiveness */
 @media (max-width: 640px) {
   .notion-gallery-grid-size-small,

--- a/packages/notion-vue/src/types/collection.ts
+++ b/packages/notion-vue/src/types/collection.ts
@@ -97,6 +97,15 @@ export interface BoardCollectionViewFormat {
 }
 
 /**
+ * List-specific collection view format
+ */
+export interface ListCollectionViewFormat {
+  list_properties?: CollectionPropertyConfig[]
+  collection_group_by?: PropertyID
+  collection_groups?: CollectionGroupConfig[]
+}
+
+/**
  * Processed board column data for rendering
  */
 export interface BoardColumnData {


### PR DESCRIPTION
## Summary
- Implement List View component for Notion collections
- Complete the collection views trilogy (Gallery, Board, List)
- Reuse existing composables and components for consistent behavior

## Changes
- `CollectionViewList.vue`: Main component with grouping support
- `ListCollectionViewFormat`: Type definition for view configuration
- CSS styles for list layout with hover states
- Routing in `NotionCollection.vue`

## Test Plan
- [x] Lint passes
- [x] Build succeeds
- [ ] Visual verification with Notion List View database

Closes #17