### PR TITLE
feat(notion-vue): implement Full Image Viewer (lightbox)

### DIFF
--- a/.please/memory/tasklist.json
+++ b/.please/memory/tasklist.json
@@ -1,45 +1,27 @@
 {
-  "session_id": "20251218-collection-board-view",
-  "feature_name": "Collection Board View",
-  "created_at": "2025-12-18T15:00:00Z",
-  "updated_at": "2025-12-18T15:00:00Z",
-  "status": "in_progress",
-  "current_phase": 7,
+  "session_id": "2025-12-18-full-image-viewer",
+  "feature_name": "Full Image Viewer",
+  "created_at": "2025-12-18T00:00:00Z",
+  "updated_at": "2025-12-18T00:00:00Z",
+  "status": "completed",
+  "current_phase": 8,
+  "issue_number": 19,
   "phases": [
-    { "number": 1, "name": "Discovery", "status": "completed", "started_at": "2025-12-18T15:00:00Z", "completed_at": "2025-12-18T15:10:00Z" },
-    { "number": 2, "name": "Codebase Exploration", "status": "completed", "started_at": "2025-12-18T15:10:00Z", "completed_at": "2025-12-18T15:20:00Z" },
-    { "number": 3, "name": "Clarifying Questions", "status": "completed", "started_at": "2025-12-18T15:20:00Z", "completed_at": "2025-12-18T15:22:00Z" },
-    { "number": 4, "name": "Architecture Design", "status": "completed", "started_at": "2025-12-18T15:22:00Z", "completed_at": "2025-12-18T15:30:00Z" },
-    { "number": 5, "name": "GitHub Issue & PR", "status": "completed", "started_at": "2025-12-18T15:30:00Z", "completed_at": "2025-12-18T15:35:00Z" },
-    { "number": 6, "name": "Implementation", "status": "completed", "started_at": "2025-12-18T15:35:00Z", "completed_at": "2025-12-18T15:50:00Z" },
-    { "number": 7, "name": "Quality Review", "status": "in_progress", "started_at": "2025-12-18T15:50:00Z" },
-    { "number": 8, "name": "PR Finalization", "status": "pending" }
+    { "number": 1, "name": "Discovery", "status": "completed", "started_at": "2025-12-18T00:00:00Z" },
+    { "number": 2, "name": "Codebase Exploration", "status": "completed" },
+    { "number": 3, "name": "Clarifying Questions", "status": "completed" },
+    { "number": 4, "name": "Architecture Design", "status": "completed" },
+    { "number": 5, "name": "GitHub Issue & PR", "status": "completed" },
+    { "number": 6, "name": "Implementation", "status": "completed" },
+    { "number": 7, "name": "Quality Review", "status": "completed" },
+    { "number": 8, "name": "PR Finalization", "status": "in_progress" }
   ],
-  "features": [
-    {
-      "id": "F002",
-      "name": "Collection Board View",
-      "priority": "medium",
-      "status": "in_progress",
-      "ref": "ref/react-notion-x/packages/react-notion-x/src/third-party/collection-view-board.tsx",
-      "description": "Kanban-style view for displaying Notion database collections with horizontal columns"
-    }
-  ],
-  "issue_number": 15,
-  "branch": "15-featnotion-vue-implement-collection-board-view",
-  "checkpoint_config": {
-    "mode": "auto",
-    "push_strategy": "batch",
-    "validation_required": true
-  },
   "tasks": [
-    { "id": "T001", "title": "Add board types to types/collection.ts", "phase": 6, "status": "pending", "parallel": true, "dependencies": [] },
-    { "id": "T002", "title": "Create useBoardColumns.ts composable", "phase": 6, "status": "pending", "parallel": true, "dependencies": [] },
-    { "id": "T003", "title": "Create EmptyIcon.vue component", "phase": 6, "status": "pending", "parallel": true, "dependencies": [] },
-    { "id": "T004", "title": "Create CollectionViewBoard.vue component", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T001", "T002", "T003"] },
-    { "id": "T005", "title": "Update NotionCollection.vue to route board view", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T004"] },
-    { "id": "T006", "title": "Add board CSS to styles.css", "phase": 6, "status": "pending", "parallel": true, "dependencies": [] },
-    { "id": "T007", "title": "Export new components in index.ts", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T004"] },
-    { "id": "T008", "title": "Update TODO.md to mark Board View completed", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T005"] }
+    { "id": "T001", "title": "Create useImageLightbox.ts composable", "phase": 6, "status": "completed", "parallel": true, "dependencies": [] },
+    { "id": "T002", "title": "Create ImageLightbox.vue component", "phase": 6, "status": "completed", "parallel": true, "dependencies": [] },
+    { "id": "T003", "title": "Add lightbox context to NotionRenderer.vue", "phase": 6, "status": "completed", "parallel": false, "dependencies": ["T001"] },
+    { "id": "T004", "title": "Add click handler to NotionAsset.vue images", "phase": 6, "status": "completed", "parallel": false, "dependencies": ["T001"] },
+    { "id": "T005", "title": "Add lightbox CSS styles", "phase": 6, "status": "completed", "parallel": false, "dependencies": ["T002"] },
+    { "id": "T006", "title": "Export new components from index.ts", "phase": 6, "status": "completed", "parallel": false, "dependencies": ["T001", "T002"] }
   ]
 }

--- a/packages/notion-vue/src/components/ImageLightbox.vue
+++ b/packages/notion-vue/src/components/ImageLightbox.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { useImageLightbox } from '../composables/useImageLightbox'
+
+const lightbox = useImageLightbox()
+const dialogRef = ref<HTMLElement | null>(null)
+
+// Handle escape key
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && lightbox?.isOpen.value) {
+    lightbox.close()
+  }
+}
+
+// Handle backdrop click
+function handleBackdropClick(e: MouseEvent) {
+  if (e.target === e.currentTarget) {
+    lightbox?.close()
+  }
+}
+
+// Focus trap
+function handleFocusTrap(e: KeyboardEvent) {
+  if (e.key !== 'Tab' || !dialogRef.value)
+    return
+
+  const focusableElements = dialogRef.value.querySelectorAll<HTMLElement>(
+    'button, [href], [tabindex]:not([tabindex="-1"])',
+  )
+  const firstElement = focusableElements[0]
+  const lastElement = focusableElements[focusableElements.length - 1]
+
+  if (e.shiftKey && document.activeElement === firstElement) {
+    e.preventDefault()
+    lastElement?.focus()
+  }
+  else if (!e.shiftKey && document.activeElement === lastElement) {
+    e.preventDefault()
+    firstElement?.focus()
+  }
+}
+
+// Setup keyboard handlers when lightbox opens
+watch(
+  () => lightbox?.isOpen.value,
+  (isOpen) => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeydown)
+      document.addEventListener('keydown', handleFocusTrap)
+      // Prevent body scroll
+      document.body.style.overflow = 'hidden'
+    }
+    else {
+      document.removeEventListener('keydown', handleKeydown)
+      document.removeEventListener('keydown', handleFocusTrap)
+      // Restore body scroll
+      document.body.style.overflow = ''
+    }
+  },
+)
+
+onMounted(() => {
+  if (lightbox?.isOpen.value) {
+    document.addEventListener('keydown', handleKeydown)
+    document.addEventListener('keydown', handleFocusTrap)
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+  document.removeEventListener('keydown', handleFocusTrap)
+  document.body.style.overflow = ''
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="lightbox-fade">
+      <div
+        v-if="lightbox?.isOpen.value && lightbox?.imageUrl.value"
+        ref="dialogRef"
+        class="notion-lightbox-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Image viewer"
+        @click="handleBackdropClick"
+      >
+        <div class="notion-lightbox-content">
+          <img
+            :src="lightbox.imageUrl.value"
+            :alt="lightbox.imageAlt.value"
+            class="notion-lightbox-image"
+          >
+        </div>
+
+        <button
+          type="button"
+          class="notion-lightbox-close"
+          aria-label="Close image viewer"
+          @click="lightbox?.close()"
+        >
+          <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style>
+.notion-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: zoom-out;
+}
+
+.notion-lightbox-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 90vw;
+  max-height: 90vh;
+  cursor: default;
+}
+
+.notion-lightbox-image {
+  max-width: 100%;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.notion-lightbox-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 50%;
+  color: white;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.notion-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.notion-lightbox-close:focus {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+/* Transition animations */
+.lightbox-fade-enter-active,
+.lightbox-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.lightbox-fade-enter-from,
+.lightbox-fade-leave-to {
+  opacity: 0;
+}
+
+.lightbox-fade-enter-active .notion-lightbox-image,
+.lightbox-fade-leave-active .notion-lightbox-image {
+  transition: transform 0.3s ease;
+}
+
+.lightbox-fade-enter-from .notion-lightbox-image {
+  transform: scale(0.95);
+}
+
+.lightbox-fade-leave-to .notion-lightbox-image {
+  transform: scale(0.95);
+}
+</style>

--- a/packages/notion-vue/src/components/NotionAsset.vue
+++ b/packages/notion-vue/src/components/NotionAsset.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Block, BookmarkBlock, EmbedBlock, ImageBlock, VideoBlock } from 'notion-types'
 import { computed } from 'vue'
+import { useImageLightbox } from '../composables/useImageLightbox'
 import { useNotionContext } from '../composables/useNotionContext'
 import NotionText from './NotionText.vue'
 
@@ -9,6 +10,7 @@ const props = defineProps<{
 }>()
 
 const { mapImageUrl } = useNotionContext()
+const lightbox = useImageLightbox()
 
 const blockType = computed(() => props.block?.type)
 
@@ -88,6 +90,14 @@ const imageFormat = computed(() => {
     blockPreserveScale: format?.block_preserve_scale,
   }
 })
+
+// Handle image click to open lightbox
+function handleImageClick() {
+  if (lightbox && imageUrl.value) {
+    const alt = caption.value?.[0]?.[0] || ''
+    lightbox.open(imageUrl.value, alt)
+  }
+}
 </script>
 
 <template>
@@ -99,11 +109,13 @@ const imageFormat = computed(() => {
         :src="imageUrl"
         :alt="caption?.[0]?.[0] || ''"
         class="notion-image"
+        :class="{ 'notion-image-zoomable': lightbox }"
         :style="{
           width: imageFormat.blockFullWidth ? '100%' : (imageFormat.width ? `${imageFormat.width}px` : undefined),
           aspectRatio: imageFormat.aspectRatio ? String(imageFormat.aspectRatio) : undefined,
         }"
         loading="lazy"
+        @click="handleImageClick"
       >
     </div>
 
@@ -190,6 +202,10 @@ const imageFormat = computed(() => {
   height: auto;
   display: block;
   object-fit: contain;
+}
+
+.notion-image-zoomable {
+  cursor: zoom-in;
 }
 
 .notion-video-iframe,

--- a/packages/notion-vue/src/components/NotionRenderer.vue
+++ b/packages/notion-vue/src/components/NotionRenderer.vue
@@ -3,9 +3,11 @@ import type { Block, PageBlock } from 'notion-types'
 import type { NotionContext, NotionRendererProps } from '../types'
 import { getBlockTitle } from 'notion-utils'
 import { computed, reactive, watchEffect } from 'vue'
+import { provideImageLightbox } from '../composables/useImageLightbox'
 import { provideNotionContext } from '../composables/useNotionContext'
 import { useTableOfContents } from '../composables/useTableOfContents'
 import { createMapPageUrl, cs, mapImageUrl as defaultMapImageUrl } from '../utils'
+import ImageLightbox from './ImageLightbox.vue'
 import NotionBlock from './NotionBlock.vue'
 import NotionCollection from './NotionCollection.vue'
 import NotionTOC from './NotionTOC.vue'
@@ -43,6 +45,9 @@ watchEffect(() => {
   Object.assign(reactiveContext, context.value)
 })
 provideNotionContext(reactiveContext)
+
+// Provide image lightbox context for descendant components
+provideImageLightbox()
 
 // Get root block
 const rootBlock = computed<Block | undefined>(() => {
@@ -189,6 +194,9 @@ const showTocSidebar = computed(() => {
       <!-- Slot for footer -->
       <slot name="footer" />
     </main>
+
+    <!-- Image Lightbox (rendered via Teleport to body) -->
+    <ImageLightbox />
   </div>
 </template>
 

--- a/packages/notion-vue/src/composables/useImageLightbox.ts
+++ b/packages/notion-vue/src/composables/useImageLightbox.ts
@@ -1,0 +1,63 @@
+import type { InjectionKey, Ref } from 'vue'
+import { inject, provide, ref } from 'vue'
+
+export interface ImageLightboxState {
+  isOpen: Ref<boolean>
+  imageUrl: Ref<string | null>
+  imageAlt: Ref<string>
+}
+
+export interface ImageLightboxActions {
+  open: (url: string, alt?: string) => void
+  close: () => void
+}
+
+export type ImageLightboxContext = ImageLightboxState & ImageLightboxActions
+
+const ImageLightboxKey: InjectionKey<ImageLightboxContext> = Symbol('ImageLightbox')
+
+/**
+ * Creates and provides the image lightbox context.
+ * Should be called in NotionRenderer to provide lightbox state to descendants.
+ */
+export function provideImageLightbox(): ImageLightboxContext {
+  const isOpen = ref(false)
+  const imageUrl = ref<string | null>(null)
+  const imageAlt = ref('')
+
+  function open(url: string, alt = '') {
+    imageUrl.value = url
+    imageAlt.value = alt
+    isOpen.value = true
+  }
+
+  function close() {
+    isOpen.value = false
+    // Delay clearing URL to allow fade-out animation
+    setTimeout(() => {
+      if (!isOpen.value) {
+        imageUrl.value = null
+        imageAlt.value = ''
+      }
+    }, 300)
+  }
+
+  const context: ImageLightboxContext = {
+    isOpen,
+    imageUrl,
+    imageAlt,
+    open,
+    close,
+  }
+
+  provide(ImageLightboxKey, context)
+  return context
+}
+
+/**
+ * Injects the image lightbox context.
+ * Returns null if used outside NotionRenderer (lightbox not available).
+ */
+export function useImageLightbox(): ImageLightboxContext | null {
+  return inject(ImageLightboxKey, null)
+}

--- a/packages/notion-vue/src/index.ts
+++ b/packages/notion-vue/src/index.ts
@@ -10,6 +10,7 @@ export { default as NestedFormLink } from './components/collection/NestedFormLin
 // Icons
 export { default as EmptyIcon } from './components/icons/EmptyIcon.vue'
 // Components
+export { default as ImageLightbox } from './components/ImageLightbox.vue'
 export { default as LazyImage } from './components/LazyImage.vue'
 export { default as NotionAsset } from './components/NotionAsset.vue'
 export { default as NotionBlock } from './components/NotionBlock.vue'
@@ -28,6 +29,8 @@ export { useCollectionData } from './composables/useCollectionData'
 export type { UseCollectionDataOptions, UseCollectionDataReturn } from './composables/useCollectionData'
 export { useCollectionGroups } from './composables/useCollectionGroups'
 export type { UseCollectionGroupsOptions, UseCollectionGroupsReturn } from './composables/useCollectionGroups'
+export { provideImageLightbox, useImageLightbox } from './composables/useImageLightbox'
+export type { ImageLightboxActions, ImageLightboxContext, ImageLightboxState } from './composables/useImageLightbox'
 export { provideNestedLinkContext, useNestedLinkContext } from './composables/useNestedLinkContext'
 export type { NestedLinkContext } from './composables/useNestedLinkContext'
 // Composables


### PR DESCRIPTION
## Summary
- Add fullscreen image viewer (lightbox) functionality for Notion images
- Clicking any image opens it in a fullscreen overlay with dark backdrop
- Supports keyboard navigation (Escape to close), click-outside to dismiss, focus trap for accessibility

## Changes
- **useImageLightbox.ts**: Composable for lightbox state management using Vue's provide/inject pattern
- **ImageLightbox.vue**: Modal component with Teleport, focus trap, keyboard handlers, and CSS transitions
- **NotionRenderer.vue**: Integrates lightbox context provider and component
- **NotionAsset.vue**: Adds click handler to images with zoom-in cursor indicator
- **index.ts**: Exports new components and composable

## Test plan
- [ ] Click on any Notion image to verify lightbox opens
- [ ] Press Escape to close lightbox
- [ ] Click outside image to close lightbox
- [ ] Click close button to dismiss
- [ ] Verify zoom-in cursor appears on hover
- [ ] Tab through focusable elements to verify focus trap
- [ ] Verify body scroll is locked when lightbox is open

Closes #19